### PR TITLE
Add link to installation instructions for libedge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ This library is a rust binding for the C++ [Edge TPU](https://github.com/google-
 ## Requirements
 
 Ensure that you have the libedge tpu library and headers installed on your system. On Linux (Debian),
-this means installed both the `libedgetpu1-std` and `libedgetpu-dev` libraries.
+this means installed both the `libedgetpu1-std` and `libedgetpu-dev` libraries. These libraries are
+already included on Coral boards with Mendel installed, but for other Debian systems follow the 
+[Debian Packages](https://coral.ai/software/#debian-packages) guide to install these libraries.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ this means installed both the `libedgetpu1-std` and `libedgetpu-dev` libraries. 
 already included on Coral boards with Mendel installed, but for other Debian systems follow the 
 [Debian Packages](https://coral.ai/software/#debian-packages) guide to install these libraries.
 
+Additionally, a valid installation of libclang is required, which can be installed on Debian systems with:
+```
+sudo apt-get update
+sudo apt-get install clang -y
+```
+
 ## Usage
 
 Add this to your `Cargo.toml`:


### PR DESCRIPTION
I had to google how to find these libraries since they aren't installable by default, and I think it would be helpful to include this in the README